### PR TITLE
feat: add Korean (ko) translation

### DIFF
--- a/lib/i18n/locales.ts
+++ b/lib/i18n/locales.ts
@@ -20,7 +20,8 @@ export type SupportedLocaleCode =
   | "es"
   | "it"
   | "pt-BR"
-  | "ja";
+  | "ja"
+  | "ko";
 
 export type SupportedLocale = {
   code: SupportedLocaleCode;
@@ -36,6 +37,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocale[] = [
   { code: "it", nativeName: "Italiano", englishName: "Italian" },
   { code: "pt-BR", nativeName: "Português (Brasil)", englishName: "Portuguese (Brazil)" },
   { code: "ja", nativeName: "日本語", englishName: "Japanese" },
+  { code: "ko", nativeName: "한국어", englishName: "Korean" },
 ] as const;
 
 export const DEFAULT_LOCALE: SupportedLocaleCode = "en";

--- a/lib/i18n/viewer-i18n.ts
+++ b/lib/i18n/viewer-i18n.ts
@@ -184,6 +184,16 @@ async function loadNamespaceFile(
           return (await import("../../locales/ja/viewer.json")).default;
       }
       break;
+    case "ko":
+      switch (namespace) {
+        case "access-form":
+          return (await import("../../locales/ko/access-form.json")).default;
+        case "dataroom":
+          return (await import("../../locales/ko/dataroom.json")).default;
+        case "viewer":
+          return (await import("../../locales/ko/viewer.json")).default;
+      }
+      break;
   }
   return {};
 }

--- a/locales/ko/access-form.json
+++ b/locales/ko/access-form.json
@@ -1,0 +1,55 @@
+{
+  "welcome": {
+    "fallback": "계속하려면 작업이 필요합니다"
+  },
+  "buttons": {
+    "continue": "계속하기",
+    "verifying": "확인하는 중..."
+  },
+  "fields": {
+    "email": {
+      "label": "이메일 주소",
+      "placeholder": "이메일을 입력하세요",
+      "errorInvalid": "유효한 이메일 주소를 입력해 주세요",
+      "sharedWithSender": "이 데이터는 발신자와 공유됩니다.",
+      "sharedWithProvider": "이 데이터는 콘텐츠 제공자와 공유됩니다."
+    },
+    "password": {
+      "label": "비밀번호",
+      "placeholder": "비밀번호를 입력하세요"
+    },
+    "name": {
+      "label": "이름",
+      "placeholder": "전체 이름을 입력하세요"
+    },
+    "url": {
+      "errorInvalid": "https://로 시작하는 유효한 URL을 입력해 주세요"
+    },
+    "phone": {
+      "placeholderDefault": "+1 123 456 7890"
+    }
+  },
+  "agreement": {
+    "fallbackPrefix": "본인은 다음 약관을 검토하였으며 이에 동의합니다"
+  },
+  "verification": {
+    "title": "이메일 주소 확인",
+    "description": "<email>{{email}}</email>(으)로 전송된 6자리 인증 코드를 입력하세요",
+    "errorInvalid": "잘못된 코드입니다. 다시 시도해 주세요.",
+    "noEmail": "이메일을 받지 못하셨나요?",
+    "resending": "코드를 재전송하는 중...",
+    "resendIn": "코드 재전송 ({{seconds}}초)",
+    "resend": "코드 재전송"
+  },
+  "footer": {
+    "sharedSecurelyVia": "이 문서는 다음을 통해 안전하게 공유됩니다",
+    "papermark": "Papermark",
+    "seeHowWeProtect": "저희가 귀하의 데이터를 어떻게 보호하는지",
+    "privacyPolicy": "개인정보 처리방침에서 확인하세요"
+  },
+  "reauth": {
+    "title": "본인 확인",
+    "description": "이 파일은 회원님이 업로드했습니다. 다시 열려면 <email>{{email}}</email>에 대한 접근 권한이 있음을 확인해 주세요.",
+    "otpDescription": "<email>{{email}}</email>(으)로 6자리 코드를 전송했습니다. 업로드한 파일에 접근하려면 아래에 입력하세요."
+  }
+}

--- a/locales/ko/dataroom.json
+++ b/locales/ko/dataroom.json
@@ -1,0 +1,172 @@
+{
+  "shell": {
+    "dataRoomEyebrow": "데이터룸",
+    "updatedOn": "{{date}}에 업데이트됨",
+    "lastUpdated": "마지막 업데이트: {{date}}",
+    "secureFooter": "보안 제공",
+    "papermark": "Papermark",
+    "copyright": "© {{year}}{{name}}"
+  },
+  "tabs": {
+    "documents": "문서",
+    "myUploads": "내 업로드"
+  },
+  "search": {
+    "placeholder": "검색...",
+    "results": "\"{{query}}\"에 대한 검색 결과",
+    "resultCount_one": "(모든 폴더에서 {{count}}개 결과)",
+    "resultCount_other": "(모든 폴더에서 {{count}}개 결과)",
+    "noMatches": "검색어와 일치하는 문서가 없습니다."
+  },
+  "breadcrumb": {
+    "home": "홈"
+  },
+  "empty": {
+    "noItems": "이용 가능한 항목이 없습니다.",
+    "noUploads": "아직 업로드된 파일이 없습니다. \"문서 추가\" 버튼을 사용해 업로드하세요."
+  },
+  "cards": {
+    "updated": "{{when}}에 업데이트됨",
+    "processing": "(처리 중...)",
+    "actionsLabel": "작업",
+    "download": "다운로드",
+    "openMenu": "메뉴 열기",
+    "openDocument": "{{name}} 문서 열기",
+    "openFolder": "{{name}} 폴더 열기",
+    "documents": "문서",
+    "folder": "폴더",
+    "folderBadge": "폴더"
+  },
+  "compactList": {
+    "name": "이름",
+    "updated": "업데이트됨",
+    "settings": "설정"
+  },
+  "trailingActions": {
+    "viewQA": "Q&A 보기",
+    "downloadDataroom": "데이터룸 다운로드",
+    "teamMemberTooltip": "팀 구성원이므로 인증을 건너뛰었습니다. 분석 데이터는 수집되지 않습니다"
+  },
+  "navToasts": {
+    "cannotDownloadPreview": "미리보기 모드에서는 데이터룸을 다운로드할 수 없습니다.",
+    "cannotDownloadDocPreview": "미리보기 모드에서는 데이터룸 문서를 다운로드할 수 없습니다.",
+    "cannotDownloadFolderPreview": "미리보기 모드에서는 데이터룸 폴더를 다운로드할 수 없습니다.",
+    "foldersNotAllowed": "폴더 다운로드는 허용되지 않습니다.",
+    "enterEmailFirst": "다운로드하려면 데이터룸에 이메일을 입력하세요.",
+    "documentStillProcessing": "문서가 아직 처리 중입니다. 잠시 후 다시 시도해 주세요.",
+    "downloadPreparing": "다운로드를 준비하는 중...",
+    "downloadSuccess": "파일이 성공적으로 다운로드되었습니다",
+    "downloadFailed": "파일 다운로드에 실패했습니다"
+  },
+  "intro": {
+    "viewIntroduction": "소개 보기",
+    "title": "{{name}}에 오신 것을 환영합니다",
+    "defaultName": "데이터룸",
+    "continueButton": "데이터룸으로 계속하기"
+  },
+  "upload": {
+    "trigger": "문서 추가",
+    "title": "데이터룸에 문서 업로드",
+    "description": "문서는 즉시 데이터룸에 표시되며 백그라운드에서 처리됩니다.",
+    "destinationLabel": "대상 폴더",
+    "selectDestination": "대상 폴더 선택",
+    "uploadingTo": "업로드 위치:",
+    "setByOwner": "(데이터룸 소유자가 설정함)",
+    "success": "문서가 성공적으로 업로드되었습니다!",
+    "successDescription": "이제 문서가 데이터룸에 표시됩니다."
+  },
+  "download": {
+    "folderTitle": "폴더 다운로드: {{name}}",
+    "dataroomTitle": "{{name}} 다운로드",
+    "defaultName": "데이터룸",
+    "chooseDescription": "다운로드를 시작하세요. 준비가 완료되면 이메일로 알림을 받을 수도 있습니다.",
+    "otpDescription": "다운로드 알림을 받으려면 이메일을 인증하세요.",
+    "ready": "파일 다운로드 준비가 완료되었습니다.",
+    "preparing": "파일을 준비하는 중...",
+    "notifyByEmail": "다운로드 준비가 완료되면 이메일로 알려주기",
+    "needsVerification": "먼저 일회용 코드로 이메일을 인증해야 합니다.",
+    "starting": "시작하는 중...",
+    "start": "다운로드 시작",
+    "cancel": "취소",
+    "viewDownloads": "다운로드 목록 보기",
+    "openDownloads": "다운로드 페이지 열기",
+    "preparingShort": "준비하는 중...",
+    "processingFiles": "{{total}}개 중 {{processed}}개 파일 처리 중...",
+    "complete": "다운로드 준비가 완료되었습니다!",
+    "failed": "다운로드에 실패했습니다.",
+    "downloadZip": "ZIP 다운로드",
+    "downloadAll": "전체 다운로드 ({{count}}개 파트)",
+    "downloadingProgress": "{{total}}개 중 {{current}}개 다운로드 중...",
+    "part": "파트 {{index}}",
+    "expiresIn": "{{time}} 후 만료",
+    "expiresLessThanHour": "1시간 미만",
+    "expiresDays_one": "{{count}}일",
+    "expiresDays_other": "{{count}}일",
+    "expiresHours_one": "{{count}}시간",
+    "expiresHours_other": "{{count}}시간",
+    "willEmailWhenReady": "이 창을 닫아도 됩니다. 준비가 완료되면 이메일로 알려드립니다.",
+    "checkBackOnDownloads": "이 창을 닫아도 됩니다. 준비가 완료되면 다운로드 페이지에서 확인하세요.",
+    "tryAgain": "다시 시도",
+    "startFailed": "다운로드를 시작하지 못했습니다",
+    "statusFetchFailed": "상태를 가져오지 못했습니다",
+    "expiresSoon": "곧"
+  },
+  "downloadsPage": {
+    "title": "내 다운로드",
+    "description": "아래에서 준비된 파일을 다운로드하세요. 링크는 3일 후 만료됩니다.",
+    "emailHeading": "다운로드 목록 보기",
+    "emailDescription": "이 데이터룸에 접근할 때 사용한 이메일을 입력하세요.",
+    "emailPlaceholder": "you@example.com",
+    "sendingCode": "코드를 전송하는 중...",
+    "continueButton": "계속하기",
+    "verifyEmailHeading": "이메일 인증",
+    "empty": "아직 다운로드한 항목이 없습니다. 데이터룸에서 다운로드를 시작하면 여기에 표시됩니다.",
+    "jobFolderPrefix": "폴더:",
+    "jobFullDataroom": "전체 데이터룸",
+    "expired": "만료됨",
+    "expiresPrefix": "{{time}} 만료",
+    "hideParts": "파트 숨기기",
+    "showParts": "파트 보기 ({{count}}개)",
+    "orIndividual": "또는 개별적으로 다운로드:",
+    "partOf": "{{total}}개 중 {{index}}번째 파트",
+    "errors": {
+      "noAccess": "이 이메일에 대한 접근 권한을 찾을 수 없습니다. 데이터룸을 열 때 사용한 이메일을 사용하세요.",
+      "rateLimit": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+      "generic": "문제가 발생했습니다."
+    }
+  },
+  "downloadOtp": {
+    "defaultDescription": "<email>{{email}}</email>(으)로 6자리 코드를 전송했습니다. 아래에 입력하여 인증하고 다운로드 알림을 받으세요.",
+    "verify": "인증",
+    "verifying": "확인하는 중...",
+    "noEmail": "이메일을 받지 못하셨나요?",
+    "resending": "전송하는 중...",
+    "resend": "코드 재전송",
+    "resendIn": "코드 재전송 ({{seconds}}초)",
+    "sendFailed": "코드 전송에 실패했습니다",
+    "invalidCode": "잘못된 코드입니다"
+  },
+  "downloadsPanel": {
+    "ready": "준비 완료",
+    "failedFallback": "실패",
+    "creatingZip": "ZIP 생성 중...",
+    "filesCount": "{{total}}개 중 {{processed}}개 파일",
+    "verifying": "접근 권한 확인 중...",
+    "buildingFileList": "파일 목록 생성 중...",
+    "preparing": "준비하는 중..."
+  },
+  "folderPicker": {
+    "home": "홈"
+  },
+  "indexFile": {
+    "trigger": "색인 파일 생성",
+    "title": "데이터룸 색인 파일 생성",
+    "description": "색인 파일을 생성할 형식을 선택하세요.",
+    "selectFormat": "형식 선택",
+    "generate": "생성",
+    "generating": "생성하는 중...",
+    "successToast": "색인 파일이 성공적으로 생성되었습니다",
+    "errorToast": "색인 생성에 실패했습니다",
+    "genericError": "문제가 발생했습니다. 다시 시도해 주세요."
+  }
+}

--- a/locales/ko/viewer.json
+++ b/locales/ko/viewer.json
@@ -1,0 +1,58 @@
+{
+  "nav": {
+    "home": "홈",
+    "viewQA": "Q&A 보기",
+    "linksOnPage": "페이지 내 링크",
+    "linksOnCurrentPage": "현재 페이지의 링크",
+    "zoomIn": "확대",
+    "zoomOut": "축소",
+    "fullscreen": "전체 화면",
+    "downloadDocument": "문서 다운로드",
+    "teamMemberTooltip": "팀 구성원이므로 인증을 건너뛰었습니다. 분석 데이터는 수집되지 않습니다",
+    "changeLanguage": "언어 변경"
+  },
+  "toasts": {
+    "preparingDownload": "다운로드를 준비하는 중...",
+    "preparingDownloadWatermark": "워터마크가 포함된 다운로드를 준비하는 중...",
+    "downloadSuccess": "파일이 성공적으로 다운로드되었습니다",
+    "downloadFailed": "파일 다운로드에 실패했습니다",
+    "cannotDownloadPreview": "미리보기 모드에서는 문서를 다운로드할 수 없습니다."
+  },
+  "downloadOnly": {
+    "title": "문서 다운로드",
+    "description": "이 문서는 다운로드만 가능합니다",
+    "button": "지금 다운로드"
+  },
+  "awayPoster": {
+    "title": "세션 보호를 위해 일시 정지했습니다",
+    "description": "{{duration}} 동안 활동이 없어 세션 보호를 위해 문서 미리보기를 일시 정지했습니다.",
+    "ariaTitle": "자동 일시 정지 세션 알림",
+    "ariaDescription": "비활성 상태로 인해 세션이 일시 정지되었습니다. 계속하려면 클릭하거나 마우스를 움직이세요.",
+    "badge": "자동 일시 정지",
+    "idleFor": "{{duration}} 동안 유휴 상태",
+    "minSec": "{{minutes}}분 {{seconds}}초",
+    "minOnly": "{{minutes}}분",
+    "secOnly": "{{seconds}}초",
+    "resume": "이어서 계속하기",
+    "moveHint": "또는 마우스를 움직이거나 아무 키나 눌러 계속하세요"
+  },
+  "poweredBy": {
+    "shareDocsVia": "다음을 통해 문서 공유"
+  },
+  "report": {
+    "trigger": "신고하기",
+    "title": "문제 신고",
+    "description": "부적절한 내용을 발견하셨나요? 확인 후 필요한 경우 조치를 취하겠습니다.",
+    "submit": "신고 제출",
+    "successToast": "신고가 성공적으로 제출되었습니다",
+    "selectTypeError": "신고 유형을 선택해 주세요.",
+    "types": {
+      "spam": "스팸, 사기 또는 부정 행위",
+      "malware": "악성코드 또는 바이러스",
+      "copyright": "저작권 침해",
+      "harmful": "유해한 콘텐츠",
+      "notWorking": "콘텐츠가 제대로 작동하지 않음",
+      "other": "기타"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Added `locales/ko/{access-form,dataroom,viewer}.json` with full Korean translations, mirroring the key structure of the English source and existing locales (`de`, `ja`, etc.)
- Registered `ko` in `lib/i18n/locales.ts` (`SupportedLocaleCode`, `SUPPORTED_LOCALES`)
- Added the `ko` case to the per-locale dynamic-import switch in `lib/i18n/viewer-i18n.ts` (required for the bundler to code-split the new locale's chunks — this step wasn't listed in the `locales.ts` doc comment, so flagging it here for future translators)

## Testing

- Verified full key parity between `locales/en/*.json` and `locales/ko/*.json` (205/205 keys match, no missing/extra keys) with a small parity script
- Verified all interpolation placeholders (`{{var}}`) and inline tags (`<email>...</email>`) are preserved identically between `en` and `ko` for every key
- Validated all three `locales/ko/*.json` files as syntactically valid JSON
- `npx tsc --noEmit` shows zero new errors introduced (diffed against the same command on `main`; the ~200 pre-existing errors are unrelated, from missing enterprise `ee/` modules not included in this OSS checkout)
- `npx eslint` clean on both modified TS files
- Confirmed no other reference to `SUPPORTED_LOCALE_CODES`/`VIEWER_NAMESPACES` in the codebase needs updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean as a supported language.
  * Added Korean translations across access forms, data rooms, downloads, viewers, navigation, and reporting flows.
  * Korean users can now access localized labels, messages, validation errors, and status updates throughout the experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->