### PR TITLE
fix(api): surface blocked-URL rejections instead of a format error

### DIFF
--- a/lib/api/documents/validate-external-url.ts
+++ b/lib/api/documents/validate-external-url.ts
@@ -96,11 +96,20 @@ export async function validateExternalDocumentUrl({
               type: "error",
               mention: true,
             });
-            throw new Error("This URL is not allowed");
+            throw new PapermarkApiError(
+              "unprocessable_entity",
+              "This URL is not allowed",
+            );
           }
         }
       }
     } catch (error) {
+      // A blocked-keyword rejection is a deliberate verdict, not a parse
+      // failure - let it through instead of relabelling it as a bad URL.
+      if (error instanceof PapermarkApiError) {
+        throw error;
+      }
+
       console.error("[validateExternalDocumentUrl] Link URL check failed", {
         teamId,
         url: describeUrlForLog(key),


### PR DESCRIPTION
A link blocked by the keyword blocklist is reported to the user as a malformed URL.

## Problem

In `validateExternalDocumentUrl` the blocklist rejection throws from **inside** the same `try` that catches it:

```ts
try {
  const parsed = new URL(key)
  ...
  if (matchedKeyword) {
    await log({ ... })
    throw new Error("This URL is not allowed")   // caught immediately below
  }
} catch (error) {
  throw new PapermarkApiError(
    "unprocessable_entity",
    "Invalid URL format for link document.",     // every failure becomes this
  )
}
```

So a user whose link was deliberately blocked is told their **URL format is invalid**. The real reason is discarded, which is also misleading when debugging a support report. The sibling `validateRedirectUrl` already keeps these cases distinct (`"This URL is not allowed"` vs `"Invalid redirect URL"`).

## Fix

Throw a `PapermarkApiError` for the blocklist verdict and re-throw it unchanged from the `catch`. Genuine parse failures and edge-config/infra errors still map to the format message, so nothing else changes.

Verified the resulting control flow:

| case | before | after |
|---|---|---|
| blocked keyword | `Invalid URL format for link document.` | `This URL is not allowed` |
| malformed URL | `Invalid URL format for link document.` | unchanged |
| valid URL | accepted | unchanged |

## Note

The repo has no test suite, so I confirmed the control flow with a standalone reproduction of both the old and new shapes rather than adding a test framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for link documents with blocked keywords.
  * Blocked URLs now display a clear “This URL is not allowed” message instead of being incorrectly reported as invalid URL formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->