### PR TITLE
feat: allow saving and reusing named watermark presets

### DIFF
--- a/components/links/link-sheet/watermark-panel/index.tsx
+++ b/components/links/link-sheet/watermark-panel/index.tsx
@@ -2,7 +2,10 @@ import React, { useEffect, useState } from "react";
 
 import { motion } from "motion/react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
+import { toast } from "sonner";
 import { z } from "zod";
+
+import { useTeam } from "@/context/team-context";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -31,6 +34,7 @@ import {
 } from "@/components/ui/sheet";
 
 import { FADE_IN_ANIMATION_SETTINGS } from "@/lib/constants";
+import { useWatermarkPresets } from "@/lib/swr/use-watermark-presets";
 import { WatermarkConfig, WatermarkConfigSchema } from "@/lib/types";
 
 import WatermarkPreview from "./watermark-preview";
@@ -53,6 +57,14 @@ export default function WatermarkConfigSheet({
   const [formValues, setFormValues] =
     useState<Partial<WatermarkConfig>>(initialConfig);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const teamInfo = useTeam();
+  const teamId = teamInfo?.currentTeam?.id;
+  const { presets, mutate: mutatePresets } = useWatermarkPresets();
+  const [selectedPresetId, setSelectedPresetId] = useState<string>("");
+  const [newPresetName, setNewPresetName] = useState<string>("");
+  const [isSavingPreset, setIsSavingPreset] = useState<boolean>(false);
+  const [isDeletingPreset, setIsDeletingPreset] = useState<boolean>(false);
 
   const previewConfig: WatermarkConfig = {
     text: formValues.text?.trim() ? formValues.text : PREVIEW_PLACEHOLDER_TEXT,
@@ -97,6 +109,86 @@ export default function WatermarkConfigSheet({
     }
   };
 
+  const handleApplyPreset = (presetId: string) => {
+    const preset = presets?.find((p) => p.id === presetId);
+    if (!preset) return;
+
+    setSelectedPresetId(presetId);
+    setFormValues(preset.config as WatermarkConfig);
+    setErrors({});
+  };
+
+  const handleSaveAsPreset = async () => {
+    if (!teamId) return;
+
+    const name = newPresetName.trim();
+    if (!name) {
+      toast.error("Please enter a name for the preset.");
+      return;
+    }
+
+    let validatedConfig: WatermarkConfig;
+    try {
+      validatedConfig = WatermarkConfigSchema.parse(formValues);
+    } catch {
+      toast.error("Fix the watermark settings above before saving a preset.");
+      return;
+    }
+
+    setIsSavingPreset(true);
+    try {
+      const response = await fetch(
+        `/api/teams/${teamId}/watermark-presets`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, config: validatedConfig }),
+        },
+      );
+
+      if (!response.ok) {
+        const { error } = await response.json().catch(() => ({}));
+        toast.error(error ?? "Failed to save watermark preset");
+        return;
+      }
+
+      const preset = await response.json();
+      toast.success("Watermark preset saved!");
+      setNewPresetName("");
+      setSelectedPresetId(preset.id);
+      mutatePresets();
+    } catch {
+      toast.error("Failed to save watermark preset");
+    } finally {
+      setIsSavingPreset(false);
+    }
+  };
+
+  const handleDeletePreset = async () => {
+    if (!teamId || !selectedPresetId) return;
+
+    setIsDeletingPreset(true);
+    try {
+      const response = await fetch(
+        `/api/teams/${teamId}/watermark-presets/${selectedPresetId}`,
+        { method: "DELETE" },
+      );
+
+      if (!response.ok) {
+        toast.error("Failed to delete watermark preset");
+        return;
+      }
+
+      toast.success("Watermark preset deleted");
+      setSelectedPresetId("");
+      mutatePresets();
+    } catch {
+      toast.error("Failed to delete watermark preset");
+    } finally {
+      setIsDeletingPreset(false);
+    }
+  };
+
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="flex h-full flex-col sm:max-w-6xl">
@@ -115,6 +207,40 @@ export default function WatermarkConfigSheet({
             {...FADE_IN_ANIMATION_SETTINGS}
           >
             <div className="flex w-full flex-col items-start gap-6 overflow-x-visible pb-4 pt-0">
+              {presets && presets.length > 0 && (
+                <div className="w-full space-y-2">
+                  <Label htmlFor="watermark-preset">Load Preset</Label>
+                  <div className="flex space-x-2">
+                    <Select
+                      name="preset"
+                      value={selectedPresetId}
+                      onValueChange={handleApplyPreset}
+                    >
+                      <SelectTrigger id="watermark-preset">
+                        <SelectValue placeholder="Select a saved preset" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {presets.map((preset) => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {selectedPresetId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isDeletingPreset}
+                        onClick={handleDeletePreset}
+                      >
+                        Delete
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )}
+
               <div className="w-full space-y-2">
                 <Label htmlFor="watermark-text">Watermark Text</Label>
                 <Input
@@ -333,6 +459,30 @@ export default function WatermarkConfigSheet({
         </div>
 
         <SheetFooter className="flex-shrink-0">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="outline">
+                Save as Preset
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 space-y-2">
+              <Label htmlFor="watermark-preset-name">Preset name</Label>
+              <Input
+                id="watermark-preset-name"
+                placeholder="e.g. Confidential"
+                value={newPresetName}
+                onChange={(e) => setNewPresetName(e.target.value)}
+              />
+              <Button
+                type="button"
+                className="w-full"
+                loading={isSavingPreset}
+                onClick={handleSaveAsPreset}
+              >
+                Save Preset
+              </Button>
+            </PopoverContent>
+          </Popover>
           <Button onClick={validateAndSave}>Save Watermark</Button>
         </SheetFooter>
       </SheetContent>

--- a/lib/swr/use-watermark-presets.ts
+++ b/lib/swr/use-watermark-presets.ts
@@ -1,0 +1,34 @@
+import { WatermarkPreset } from "@prisma/client";
+
+import { useTeam } from "@/context/team-context";
+import useSWR from "swr";
+
+import { fetcher } from "@/lib/utils";
+
+export function useWatermarkPresets() {
+  const teamInfo = useTeam();
+  const teamId = teamInfo?.currentTeam?.id;
+
+  const {
+    data,
+    isValidating,
+    error,
+    isLoading,
+    mutate,
+  } = useSWR<{ presets: WatermarkPreset[] }>(
+    teamId && `/api/teams/${teamId}/watermark-presets`,
+    fetcher,
+    {
+      dedupingInterval: 10000,
+    },
+  );
+
+  return {
+    presets: data?.presets,
+    loading: data ? false : true,
+    isValidating,
+    error,
+    isLoading,
+    mutate,
+  };
+}

--- a/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
+++ b/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
@@ -38,24 +38,28 @@ export default async function handle(
       return res.status(403).end("Unauthorized to access this team");
     }
   } catch (error) {
-    errorhandler(error, res);
+    return errorhandler(error, res);
   }
 
   if (req.method === "DELETE") {
     // DELETE /api/teams/:teamId/watermark-presets/[id]
-    const preset = await prisma.watermarkPreset.findUnique({
-      where: { id, teamId },
-    });
+    try {
+      const preset = await prisma.watermarkPreset.findUnique({
+        where: { id, teamId },
+      });
 
-    if (!preset) {
-      return res.status(404).json({ error: "Watermark preset not found" });
+      if (!preset) {
+        return res.status(404).json({ error: "Watermark preset not found" });
+      }
+
+      await prisma.watermarkPreset.delete({
+        where: { id, teamId },
+      });
+
+      return res.status(204).end();
+    } catch (error) {
+      return errorhandler(error, res);
     }
-
-    await prisma.watermarkPreset.delete({
-      where: { id, teamId },
-    });
-
-    return res.status(204).end();
   } else {
     // We only allow DELETE requests
     res.setHeader("Allow", ["DELETE"]);

--- a/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
+++ b/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
@@ -1,0 +1,64 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { getServerSession } from "next-auth";
+
+import { errorhandler } from "@/lib/errorHandler";
+import prisma from "@/lib/prisma";
+import { CustomUser } from "@/lib/types";
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).end("Unauthorized");
+  }
+
+  const { teamId, id } = req.query as { teamId: string; id: string };
+
+  try {
+    const team = await prisma.team.findUnique({
+      where: {
+        id: teamId,
+      },
+      select: {
+        id: true,
+        users: { select: { userId: true } },
+      },
+    });
+
+    // check that the user is member of the team, otherwise return 403
+    const teamUsers = team?.users;
+    const isUserPartOfTeam = teamUsers?.some(
+      (user) => user.userId === (session.user as CustomUser).id,
+    );
+    if (!isUserPartOfTeam) {
+      return res.status(403).end("Unauthorized to access this team");
+    }
+  } catch (error) {
+    errorhandler(error, res);
+  }
+
+  if (req.method === "DELETE") {
+    // DELETE /api/teams/:teamId/watermark-presets/[id]
+    const preset = await prisma.watermarkPreset.findUnique({
+      where: { id, teamId },
+    });
+
+    if (!preset) {
+      return res.status(404).json({ error: "Watermark preset not found" });
+    }
+
+    await prisma.watermarkPreset.delete({
+      where: { id, teamId },
+    });
+
+    return res.status(204).end();
+  } else {
+    // We only allow DELETE requests
+    res.setHeader("Allow", ["DELETE"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
+++ b/pages/api/teams/[teamId]/watermark-presets/[id]/index.ts
@@ -44,17 +44,13 @@ export default async function handle(
   if (req.method === "DELETE") {
     // DELETE /api/teams/:teamId/watermark-presets/[id]
     try {
-      const preset = await prisma.watermarkPreset.findUnique({
+      const { count } = await prisma.watermarkPreset.deleteMany({
         where: { id, teamId },
       });
 
-      if (!preset) {
+      if (count === 0) {
         return res.status(404).json({ error: "Watermark preset not found" });
       }
-
-      await prisma.watermarkPreset.delete({
-        where: { id, teamId },
-      });
 
       return res.status(204).end();
     } catch (error) {

--- a/pages/api/teams/[teamId]/watermark-presets/index.ts
+++ b/pages/api/teams/[teamId]/watermark-presets/index.ts
@@ -48,39 +48,62 @@ export default async function handle(
       return res.status(403).end("Unauthorized to access this team");
     }
   } catch (error) {
-    errorhandler(error, res);
+    return errorhandler(error, res);
   }
 
   if (req.method === "GET") {
     // GET /api/teams/:teamId/watermark-presets
-    const presets = await prisma.watermarkPreset.findMany({
-      where: { teamId },
-      orderBy: { name: "asc" },
-    });
+    try {
+      const presets = await prisma.watermarkPreset.findMany({
+        where: { teamId },
+        orderBy: { name: "asc" },
+      });
 
-    return res.status(200).json({ presets });
+      return res.status(200).json({ presets });
+    } catch (error) {
+      return errorhandler(error, res);
+    }
   } else if (req.method === "POST") {
     // POST /api/teams/:teamId/watermark-presets
-    const { name, config } = createWatermarkPresetBodySchema.parse(req.body);
+    try {
+      const { name, config } = createWatermarkPresetBodySchema.parse(
+        req.body,
+      );
 
-    const existingPreset = await prisma.watermarkPreset.findFirst({
-      where: { teamId, name },
-    });
-    if (existingPreset) {
-      return res.status(400).json({
-        error: "A watermark preset with that name already exists.",
+      const existingPreset = await prisma.watermarkPreset.findFirst({
+        where: { teamId, name },
       });
+      if (existingPreset) {
+        return res.status(400).json({
+          error: "A watermark preset with that name already exists.",
+        });
+      }
+
+      const preset = await prisma.watermarkPreset.create({
+        data: {
+          name,
+          config,
+          teamId,
+        },
+      });
+
+      return res.status(200).json(preset);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.errors[0].message });
+      }
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "P2002"
+      ) {
+        return res.status(400).json({
+          error: "A watermark preset with that name already exists.",
+        });
+      }
+      return errorhandler(error, res);
     }
-
-    const preset = await prisma.watermarkPreset.create({
-      data: {
-        name,
-        config,
-        teamId,
-      },
-    });
-
-    return res.status(200).json(preset);
   } else {
     // We only allow GET and POST requests
     res.setHeader("Allow", ["GET", "POST"]);

--- a/pages/api/teams/[teamId]/watermark-presets/index.ts
+++ b/pages/api/teams/[teamId]/watermark-presets/index.ts
@@ -1,0 +1,89 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+
+import { errorhandler } from "@/lib/errorHandler";
+import prisma from "@/lib/prisma";
+import { CustomUser, WatermarkConfigSchema } from "@/lib/types";
+
+export const createWatermarkPresetBodySchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required.")
+    .max(50, "Name is too long."),
+  config: WatermarkConfigSchema,
+});
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).end("Unauthorized");
+  }
+
+  const { teamId } = req.query as { teamId: string };
+
+  try {
+    const team = await prisma.team.findUnique({
+      where: {
+        id: teamId,
+      },
+      select: {
+        id: true,
+        users: { select: { userId: true } },
+      },
+    });
+
+    // check that the user is member of the team, otherwise return 403
+    const teamUsers = team?.users;
+    const isUserPartOfTeam = teamUsers?.some(
+      (user) => user.userId === (session.user as CustomUser).id,
+    );
+    if (!isUserPartOfTeam) {
+      return res.status(403).end("Unauthorized to access this team");
+    }
+  } catch (error) {
+    errorhandler(error, res);
+  }
+
+  if (req.method === "GET") {
+    // GET /api/teams/:teamId/watermark-presets
+    const presets = await prisma.watermarkPreset.findMany({
+      where: { teamId },
+      orderBy: { name: "asc" },
+    });
+
+    return res.status(200).json({ presets });
+  } else if (req.method === "POST") {
+    // POST /api/teams/:teamId/watermark-presets
+    const { name, config } = createWatermarkPresetBodySchema.parse(req.body);
+
+    const existingPreset = await prisma.watermarkPreset.findFirst({
+      where: { teamId, name },
+    });
+    if (existingPreset) {
+      return res.status(400).json({
+        error: "A watermark preset with that name already exists.",
+      });
+    }
+
+    const preset = await prisma.watermarkPreset.create({
+      data: {
+        name,
+        config,
+        teamId,
+      },
+    });
+
+    return res.status(200).json(preset);
+  } else {
+    // We only allow GET and POST requests
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/prisma/migrations/20260824181435_add_watermark_presets/migration.sql
+++ b/prisma/migrations/20260824181435_add_watermark_presets/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "WatermarkPreset" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WatermarkPreset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WatermarkPreset_teamId_idx" ON "WatermarkPreset"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WatermarkPreset_teamId_name_key" ON "WatermarkPreset"("teamId", "name");
+
+-- AddForeignKey
+ALTER TABLE "WatermarkPreset" ADD CONSTRAINT "WatermarkPreset_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/link.prisma
+++ b/prisma/schema/link.prisma
@@ -173,6 +173,21 @@ model LinkPreset {
   @@index([teamId])
 }
 
+model WatermarkPreset {
+  id     String @id @default(cuid())
+  name   String
+  teamId String
+  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  config Json // WatermarkConfig: {text, isTiled, position, rotation, color, fontSize, opacity}
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([teamId, name])
+  @@index([teamId])
+}
+
 enum CustomFieldType {
   SHORT_TEXT
   LONG_TEXT

--- a/prisma/schema/team.prisma
+++ b/prisma/schema/team.prisma
@@ -20,6 +20,7 @@ model Team {
 
   permissionGroups  PermissionGroup[]
   linkPresets       LinkPreset[] // Link presets for the team
+  watermarkPresets  WatermarkPreset[] // Named, reusable watermark configurations for the team
   incomingWebhooks  IncomingWebhook[]
   restrictedTokens  RestrictedToken[]
   webhooks          Webhook[]


### PR DESCRIPTION
## Summary

Users had to recreate their watermark configuration (text, position, rotation, color, font size, opacity) from scratch for every new link. This adds the ability to save a watermark config as a named preset and reuse it later, via "Save as Preset" / "Load Preset" in the existing watermark configuration sheet.

## Why

Closes #1951.

## How

- **New model**: `WatermarkPreset` (`teamId`, `name`, `config` JSON, unique on `[teamId, name]`) — deliberately separate from the existing `LinkPreset` model, which is a single team-wide default applied to all new links. This issue is asking for a library of *multiple, named, user-selectable* watermark configs, which is a different concept, so I didn't want to overload `LinkPreset` with it.
- **API**: `GET`/`POST /api/teams/:teamId/watermark-presets` and `DELETE /api/teams/:teamId/watermark-presets/:id`, mirroring the existing `tags` endpoints exactly (same auth/team-membership check pattern, same Zod validation approach).
- **UI** (`watermark-panel/index.tsx`): a "Load Preset" dropdown (only shown once at least one preset exists) with a delete action for the selected preset, and a "Save as Preset" popover in the sheet footer that names and persists the current form values as a new preset. Reuses `WatermarkConfigSchema` for validation before saving, so a preset can never be saved in an invalid state.

No new dependencies.

## Testing

I don't have a way to run the app fully end-to-end from this environment against a *real* logged-in session, but I verified as much as I could at each layer:

- **Migration**: spun up a local, disposable PostgreSQL instance, applied all ~150 existing migrations cleanly (baseline), then generated and applied this PR's migration with `prisma migrate dev` (not hand-written) — verified the resulting table/index/FK structure directly via `psql \d`.
- **Data layer**: wrote a throwaway script exercising the Prisma model directly against that same database — create, list, the `[teamId, name]` uniqueness constraint (confirmed it correctly rejects a duplicate with `P2002`), delete, and cascade-delete on team removal. All passed.
- **Typecheck**: `npx tsc --noEmit` — zero errors introduced. Note the repo currently has ~210 pre-existing errors on `main` (confirmed identical count with and without this PR's changes) — these come from the `ee/` enterprise module not resolving in a plain public checkout, same root cause as #2179 and #2186.
- **Lint**: `npx eslint` on all changed/new files — clean.
- **Build**: `next build` currently fails on `main` for the same `ee/`-module reason as #2186 ("main branch fails to compile"), so I couldn't get a full production build here — pre-existing, unrelated to this change.
- **Route compilation**: ran `next dev` and hit the new `watermark-presets` API route directly. It compiled successfully (confirmed in the Next.js dev server log). The request then 500'd — but I confirmed the *existing, already-merged* `tags` endpoint 500s identically on the same request in this environment, due to Stripe not being configured (unrelated to this PR, purely a local env-var gap on my side).

Given all of this, I'm confident in the data layer and the route logic, but a maintainer click-through of the actual Save/Load/Delete UI flow with a real session would be very welcome before merge.

## Related Issue

Closes #1951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable watermark presets for saving, loading, selecting, and deleting named watermark configurations.
  * Added preset controls to the watermark configuration panel, including validation and success or error notifications.
  * Presets are scoped to each team and prevent duplicate names.
  * Preset selections refresh automatically so the latest saved configurations are available.
  * Added clear feedback when preset operations succeed or cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->