### PR TITLE
docs: document the required UPSTASH_REDIS_REST_URL/_TOKEN vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ GOOGLE_CLIENT_SECRET=
 # This variable is from Resend to send emails
 RESEND_API_KEY=
 
+# Upstash Redis (REST) – required for rate limiting, job stores, caching, and
+# email login codes (without this, sign-in via email will not work even with
+# RESEND_API_KEY set). Distinct from the "REDIS LOCKER" pair further below.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
 # This variable is from Tinybird to publish and read event data
 TINYBIRD_TOKEN=
 


### PR DESCRIPTION
## Summary

`.env.example` documents `UPSTASH_REDIS_REST_LOCKER_URL`/`_TOKEN` (used only for the tus.io upload lock) but not `UPSTASH_REDIS_REST_URL`/`_TOKEN` — the actual pair read in `lib/redis.ts` and used across rate limiting, job stores, caching, and (concretely) storing email login codes (`lib/emails/send-verification-request.ts`).

## Why

Traced this while helping answer [discussion #787](https://github.com/papermark/papermark/discussions/787) ("Auth in local dev environment?"). Email sign-in silently fails without Redis configured — not just `RESEND_API_KEY` — and there was no way to discover that from `.env.example` alone, since the only Redis vars shown there are the locker-specific ones for an unrelated purpose.

## Change

Adds the two missing vars to `.env.example` with a comment explaining what they're for and why they're distinct from the locker pair right below them.

## Related

Related to discussion #787.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for connecting to Upstash Redis.
  * Documented the Redis settings required for rate limiting, job storage, caching, and email sign-in codes.
  * Clarified that these settings are separate from the Redis locker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->