### PR TITLE
fix: revalidate cache button hits a missing route

### DIFF
--- a/pages/api/links/[id]/revalidate.ts
+++ b/pages/api/links/[id]/revalidate.ts
@@ -41,12 +41,18 @@ export default async function handle(
           teamId,
         },
       },
+      select: { status: true, blockedAt: true },
     });
 
     if (!teamAccess) {
       return res.status(403).end("Forbidden");
     }
 
+    if (teamAccess.status !== "ACTIVE" || teamAccess.blockedAt) {
+      return res
+        .status(403)
+        .json({ error: "Your access to this team is not active." });
+    }
     const link = await prisma.link.findUnique({
       where: { id, teamId, deletedAt: null },
       select: { id: true },

--- a/pages/api/links/[id]/revalidate.ts
+++ b/pages/api/links/[id]/revalidate.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 
 import { revalidateLinkById } from "@/lib/api/links/revalidate";
+import { enforceLinkMemberScope } from "@/lib/api/rbac/guard";
 import { errorhandler } from "@/lib/errorHandler";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
@@ -24,9 +25,10 @@ export default async function handle(
   }
 
   const { id } = req.query as { id: string };
-  const { teamId } = req.body as { teamId?: string };
+  const teamId =
+    req.body && typeof req.body === "object" ? req.body.teamId : undefined;
 
-  if (!teamId) {
+  if (typeof teamId !== "string" || teamId.length === 0) {
     return res.status(400).json({ error: "teamId is required" });
   }
 
@@ -40,7 +42,7 @@ export default async function handle(
           teamId,
         },
       },
-      select: { status: true, blockedAt: true },
+      select: { status: true, blockedAt: true, role: true },
     });
 
     if (!teamAccess) {
@@ -59,6 +61,17 @@ export default async function handle(
 
     if (!link) {
       return res.status(404).json({ error: "Link not found" });
+    }
+
+    const scopeDenied = await enforceLinkMemberScope({
+      userId,
+      teamId,
+      linkId: link.id,
+      res,
+      role: teamAccess.role,
+    });
+    if (scopeDenied) {
+      return;
     }
 
     const revalidated = await revalidateLinkById(id);

--- a/pages/api/links/[id]/revalidate.ts
+++ b/pages/api/links/[id]/revalidate.ts
@@ -1,0 +1,68 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getServerSession } from "next-auth/next";
+
+import { revalidateLinkById } from "@/lib/api/links/revalidate";
+import { errorhandler } from "@/lib/errorHandler";
+import prisma from "@/lib/prisma";
+import { CustomUser } from "@/lib/types";
+
+import { authOptions } from "../../auth/[...nextauth]";
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  // POST /api/links/:id/revalidate
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).end("Unauthorized");
+  }
+
+  const { id } = req.query as { id: string };
+  const { teamId } = req.body as { teamId?: string };
+
+  if (!teamId) {
+    return res.status(400).json({ error: "teamId is required" });
+  }
+
+  const userId = (session.user as CustomUser).id;
+
+  try {
+    const teamAccess = await prisma.userTeam.findUnique({
+      where: {
+        userId_teamId: {
+          userId,
+          teamId,
+        },
+      },
+    });
+
+    if (!teamAccess) {
+      return res.status(403).end("Forbidden");
+    }
+
+    const link = await prisma.link.findUnique({
+      where: { id, teamId, deletedAt: null },
+      select: { id: true },
+    });
+
+    if (!link) {
+      return res.status(404).json({ error: "Link not found" });
+    }
+
+    const revalidated = await revalidateLinkById(id);
+    if (!revalidated) {
+      return res.status(500).json({ error: "Failed to revalidate link cache" });
+    }
+
+    return res.status(200).json({ revalidated: true });
+  } catch (error) {
+    return errorhandler(error, res);
+  }
+}

--- a/pages/api/links/[id]/revalidate.ts
+++ b/pages/api/links/[id]/revalidate.ts
@@ -18,7 +18,6 @@ export default async function handle(
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  // POST /api/links/:id/revalidate
   const session = await getServerSession(req, res, authOptions);
   if (!session) {
     return res.status(401).end("Unauthorized");


### PR DESCRIPTION
closes #2201

the row action in `components/links/links-table.tsx` posts to `/api/links/:id/revalidate`, but that handler was never added. `/api/revalidate` is get-only and gated on `REVALIDATE_TOKEN`, so the client cant call it.

this adds `POST /api/links/:id/revalidate` with the same session + team membership check as archive/duplicate, then calls `revalidateLinkById` (which already talks to the secret endpoint server-side).

tested by tracing the fetch path against the new handler. didnt click it in the ui since i dont have a running papermark env with isr set up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated option to refresh link data.
  * Refresh requests now verify supported methods, active team access, and link availability.
  * Invalid or unauthorized requests receive appropriate error responses.

* **Bug Fixes**
  * Improved access control for link refresh requests by enforcing team membership roles and link-level permissions.
  * Added safer validation for team information submitted with refresh requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
