### PR TITLE
fix: document overview returning the same version payload twice

### DIFF
--- a/lib/swr/use-dataroom-document.ts
+++ b/lib/swr/use-dataroom-document.ts
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useTeam } from "@/context/team-context";
 import useSWR from "swr";
 
-import { DocumentWithVersion } from "@/lib/types";
+import { DocumentOverviewDocument } from "@/lib/types";
 import { fetcher } from "@/lib/utils";
 
 interface DataroomDocumentOverview {
@@ -11,11 +11,7 @@ interface DataroomDocumentOverview {
   documentId: string;
   dataroom: { id: string; name: string };
   dataroomFolder: { id: string; name: string; path: string } | null;
-  document: DocumentWithVersion & {
-    hasPageLinks: boolean;
-    isEmpty: boolean;
-    primaryVersion: any;
-  };
+  document: DocumentOverviewDocument;
   limits: {
     canAddLinks: boolean;
     canAddDocuments: boolean;

--- a/lib/swr/use-document-overview.ts
+++ b/lib/swr/use-document-overview.ts
@@ -3,15 +3,11 @@ import { useRouter } from "next/router";
 import { useTeam } from "@/context/team-context";
 import useSWR from "swr";
 
-import { DocumentWithVersion } from "@/lib/types";
+import { DocumentOverviewDocument } from "@/lib/types";
 import { fetcher } from "@/lib/utils";
 
 interface DocumentOverview {
-  document: DocumentWithVersion & {
-    hasPageLinks: boolean;
-    isEmpty: boolean;
-    primaryVersion: any;
-  };
+  document: DocumentOverviewDocument;
   limits: {
     canAddLinks: boolean;
     canAddDocuments: boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,12 @@ export interface DocumentWithVersion extends Document {
   hasPageLinks: boolean;
 }
 
+export type DocumentOverviewDocument = Omit<DocumentWithVersion, "versions"> & {
+  hasPageLinks: boolean;
+  isEmpty: boolean;
+  primaryVersion: DocumentVersion;
+};
+
 export interface LinkWithViews extends Link {
   _count: {
     views: number;

--- a/pages/api/teams/[teamId]/datarooms/[id]/documents/[documentId]/overview.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/documents/[documentId]/overview.ts
@@ -182,15 +182,16 @@ export default async function handle(
     }
 
     const document = dataroomDocument.document;
+    const { versions, _count, ...documentFields } = document;
 
     const [limits, featureFlags] = await Promise.all([
       getLimits({ teamId, userId }),
       getFeatureFlags({ teamId }),
     ]);
 
-    const primaryVersion = document.versions[0];
-    const hasLinks = document._count.links > 0;
-    const hasViews = document._count.views > 0;
+    const primaryVersion = versions[0];
+    const hasLinks = _count.links > 0;
+    const hasViews = _count.views > 0;
 
     // Direct document-link visits (no data room). Surfaced as a small count so
     // full team members know the document has activity outside this room. Never
@@ -224,7 +225,7 @@ export default async function handle(
       dataroom: dataroomDocument.dataroom,
       dataroomFolder: dataroomDocument.folder,
       document: {
-        ...serializeFileSize(document),
+        ...serializeFileSize(documentFields),
         primaryVersion: serializeFileSize(primaryVersion),
         hasPageLinks,
         isEmpty: !hasLinks && !hasViews,
@@ -244,8 +245,8 @@ export default async function handle(
         isTrial: team?.plan.includes("drtrial") || false,
       },
       counts: {
-        links: document._count.links,
-        views: document._count.views,
+        links: _count.links,
+        views: _count.views,
         otherViewCount,
       },
     };

--- a/pages/api/teams/[teamId]/documents/[id]/overview.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/overview.ts
@@ -131,9 +131,10 @@ export default async function handle(
       });
     }
 
-    const primaryVersion = document.versions[0];
-    const hasLinks = document._count.links > 0;
-    const hasViews = document._count.views > 0;
+    const { versions, _count, ...documentFields } = document;
+    const primaryVersion = versions[0];
+    const hasLinks = _count.links > 0;
+    const hasViews = _count.views > 0;
 
     // Check for page links only if needed
     let hasPageLinks = false;
@@ -152,7 +153,7 @@ export default async function handle(
     // Basic response for instant loading
     const response = {
       document: {
-        ...serializeFileSize(document),
+        ...serializeFileSize(documentFields),
         primaryVersion: serializeFileSize(primaryVersion),
         hasPageLinks,
         isEmpty: !hasLinks && !hasViews, // Flag for empty state optimization
@@ -172,8 +173,8 @@ export default async function handle(
         isTrial: team?.plan.includes("drtrial") || false,
       },
       counts: {
-        links: document._count.links,
-        views: document._count.views,
+        links: _count.links,
+        views: _count.views,
       },
     };
 


### PR DESCRIPTION
closes #2175

`GET /api/teams/:teamId/documents/:id/overview` was spreading the prisma document (so `versions[0]` and `_count` went out on `document`) and then also attaching `primaryVersion` and top-level `counts`. same pattern on the dataroom-scoped overview.

the document page already reads `primaryVersion` and `counts` from `useDocumentOverview`, so the extra copies were unused payload. kept the prisma `versions` query internally, just stripped it (and `_count`) from the json.

also applied to the dataroom document overview so the two routes stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in document overview data handling across standard and dataroom-scoped views.
  * Preserved existing document details, file-size information, link and view counts, version information, page-link indicators, and empty-state behavior.
  * Standardized the document overview data structure used by the application without changing the visible experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
