### PR TITLE
fix: squashed icons in the help center dialog

### DIFF
--- a/components/sidebar/nav-user.tsx
+++ b/components/sidebar/nav-user.tsx
@@ -201,7 +201,7 @@ export function NavUser() {
 
       <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
         <DialogContent className="max-w-[550px] gap-0 overflow-hidden border-none p-0 shadow-lg">
-          <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[cmdk-item]_svg]:shrink-0">
             <CommandInput
               placeholder="Search help articles..."
               className="h-14 border-none px-4 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
@@ -222,7 +222,7 @@ export function NavUser() {
                       setSearchOpen(false);
                     }}
                   >
-                    <FileTextIcon className="mr-2 h-4 w-4 text-[#fb7a00]" />
+                    <FileTextIcon className="mr-2 h-4 w-4 shrink-0 text-[#fb7a00]" />
                     <div className="flex flex-col">
                       <span className="text-sm font-medium">
                         {article.data.title}


### PR DESCRIPTION
closes #2173

help center rows are cmdk items (flex). long titles were eating width and the `FileTextIcon` got compressed.

added `shrink-0` on the icon and on `svg` inside cmdk items so the orange doc icon keeps its box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved help center search results by preventing article icons from shrinking in the search dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
