### PR TITLE
fix: /api/faqs and slack oauth failing vercel static generation

### DIFF
--- a/app/(ee)/api/faqs/route.ts
+++ b/app/(ee)/api/faqs/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export const dynamic = "force-dynamic";
-
 import { z } from "zod";
 
 import { verifyDataroomSession } from "@/lib/auth/dataroom-auth";
 import prisma from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
 
 // Validation schema for query parameters
 const visitorFAQParamsSchema = z.object({

--- a/app/(ee)/api/faqs/route.ts
+++ b/app/(ee)/api/faqs/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 import { z } from "zod";
 
 import { verifyDataroomSession } from "@/lib/auth/dataroom-auth";

--- a/app/api/integrations/slack/oauth/authorize/route.ts
+++ b/app/api/integrations/slack/oauth/authorize/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 
-export const dynamic = "force-dynamic";
-
 import { authOptions } from "@/lib/auth/auth-options";
 import { getServerSession } from "next-auth/next";
 import { z } from "zod";
@@ -10,6 +8,8 @@ import { getSlackInstallationUrl } from "@/lib/integrations/slack/install";
 import prisma from "@/lib/prisma";
 import { CustomUser } from "@/lib/types";
 import { getSearchParams } from "@/lib/utils/get-search-params";
+
+export const dynamic = "force-dynamic";
 
 const oAuthAuthorizeSchema = z.object({
   teamId: z.string().cuid(),

--- a/app/api/integrations/slack/oauth/authorize/route.ts
+++ b/app/api/integrations/slack/oauth/authorize/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 import { authOptions } from "@/lib/auth/auth-options";
 import { getServerSession } from "next-auth/next";
 import { z } from "zod";


### PR DESCRIPTION
closes #1905

`app/(ee)/api/faqs/route.ts` reads `req.nextUrl.searchParams`, and the slack oauth authorize route uses session headers. next still tried to statically render them, which fails the vercel build with `DYNAMIC_SERVER_USAGE`.

set `export const dynamic = "force-dynamic"` on both routes called out in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the placement of route configuration settings for FAQ and Slack integration endpoints.
  * No user-facing functionality or runtime behavior has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
