### PR TITLE
feat: rename hidden documents and folders from the list

### DIFF
--- a/components/documents/edit-document-name-modal.tsx
+++ b/components/documents/edit-document-name-modal.tsx
@@ -295,6 +295,8 @@ export function EditDocumentNameModal({
         });
       }
 
+      mutate(`/api/teams/${teamId}/documents/hidden`);
+
       setOpen(false);
     } catch {
       toast.error("Error updating document name. Please try again.");

--- a/components/documents/hidden-document-card.tsx
+++ b/components/documents/hidden-document-card.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { TeamContextType } from "@/context/team-context";
 import {
   EyeIcon,
+  FilePenIcon,
   MoreVertical,
   ServerIcon,
   TrashIcon,
@@ -18,6 +19,7 @@ import { cn, nFormatter, timeAgo } from "@/lib/utils";
 import { fileIcon } from "@/lib/utils/get-file-icon";
 
 import BarChart from "@/components/shared/icons/bar-chart";
+import { EditDocumentNameModal } from "@/components/documents/edit-document-name-modal";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -50,6 +52,7 @@ export function HiddenDocumentCard({
   const [isFirstClick, setIsFirstClick] = useState<boolean>(false);
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [isHovered, setIsHovered] = useState<boolean>(false);
+  const [renameOpen, setRenameOpen] = useState<boolean>(false);
 
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
@@ -271,6 +274,16 @@ export function HiddenDocumentCard({
               <EyeIcon className="mr-2 h-4 w-4" />
               Show in All Documents
             </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                setRenameOpen(true);
+                setMenuOpen(false);
+              }}
+            >
+              <FilePenIcon className="mr-2 h-4 w-4" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={(event) => handleButtonClick(event, prismaDocument.id)}
@@ -287,6 +300,14 @@ export function HiddenDocumentCard({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      {renameOpen ? (
+        <EditDocumentNameModal
+          open={renameOpen}
+          setOpen={setRenameOpen}
+          documentId={prismaDocument.id}
+          documentName={prismaDocument.name}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/documents/hidden-folder-card.tsx
+++ b/components/documents/hidden-folder-card.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { TeamContextType } from "@/context/team-context";
 import {
   EyeIcon,
+  FolderPenIcon,
   FolderIcon,
   MoreVertical,
   TrashIcon,
@@ -15,6 +16,7 @@ import { mutate } from "swr";
 import { FolderWithCount } from "@/lib/swr/use-documents";
 import { timeAgo } from "@/lib/utils";
 
+import { EditFolderModal } from "@/components/folders/edit-folder-modal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -44,6 +46,7 @@ export function HiddenFolderCard({
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [isHovered, setIsHovered] = useState<boolean>(false);
+  const [renameOpen, setRenameOpen] = useState<boolean>(false);
 
   const folderPath = `/documents/tree${folder.path}`;
 
@@ -153,6 +156,17 @@ export function HiddenFolderCard({
               <EyeIcon className="mr-2 h-4 w-4" />
               Show in All Documents
             </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setRenameOpen(true);
+                setMenuOpen(false);
+              }}
+            >
+              <FolderPenIcon className="mr-2 h-4 w-4" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={(event) => {
@@ -168,6 +182,16 @@ export function HiddenFolderCard({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      {renameOpen ? (
+        <EditFolderModal
+          open={renameOpen}
+          setOpen={setRenameOpen}
+          folderId={folder.id}
+          name={folder.name}
+          icon={folder.icon}
+          color={folder.color}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/folders/edit-folder-modal.tsx
+++ b/components/folders/edit-folder-modal.tsx
@@ -147,6 +147,7 @@ export function EditFolderModal({
       mutate(
         `/api/teams/${teamInfo?.currentTeam?.id}/${endpointTargetType}${parentFolderPath}`,
       );
+      mutate(`/api/teams/${teamInfo?.currentTeam?.id}/documents/hidden`);
     } catch (error) {
       setLoading(false);
       toast.error("Error updating folder. Please try again.");


### PR DESCRIPTION
closes #2194

visible document and folder cards already have rename. the hidden list only had unhide + delete, which is what #2194 is actually about.

wired the same \`EditDocumentNameModal\` / \`EditFolderModal\` into \`hidden-document-card\` and \`hidden-folder-card\`. also revalidate \`/documents/hidden\` after a rename so the list updates without a refresh.

rename still uses the existing update-name / folder update endpoints. no new api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to rename hidden documents and folders directly from their context menus.
  - Added rename dialogs for hidden items.

- **Bug Fixes**
  - Hidden document and folder listings now refresh automatically after a rename, ensuring updated names appear immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
