### PR TITLE
fix: preserve unsaved settings list edits

### DIFF
--- a/components/settings/global-block-list-form.tsx
+++ b/components/settings/global-block-list-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useTeam } from "@/context/team-context";
 import { toast } from "sonner";
@@ -29,24 +29,20 @@ export default function GlobalBlockListForm() {
   const [blockListInput, setBlockListInput] = useState("");
   const [initialBlockListInput, setInitialBlockListInput] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const hasUnsavedChanges = blockListInput !== initialBlockListInput;
 
   useEffect(() => {
-    if (blockList) {
+    if (blockList && !hasUnsavedChanges) {
       const val = blockList.join("\n");
       setBlockListInput(val);
       setInitialBlockListInput(val);
     }
-  }, [blockList]);
+  }, [blockList, hasUnsavedChanges]);
 
   const { invalid: invalidEntries } = validateList(blockListInput, "both");
 
-  const saveDisabled = useMemo(() => {
-    return (
-      isSaving ||
-      blockListInput === initialBlockListInput ||
-      invalidEntries.length > 0
-    );
-  }, [isSaving, blockListInput, initialBlockListInput, invalidEntries]);
+  const saveDisabled =
+    isSaving || !hasUnsavedChanges || invalidEntries.length > 0;
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -64,6 +60,9 @@ export default function GlobalBlockListForm() {
         throw new Error(error || "Failed to update block list.");
       }
       await mutate();
+      const savedValue = entries.join("\n");
+      setBlockListInput(savedValue);
+      setInitialBlockListInput(savedValue);
       return res.json();
     });
 
@@ -98,6 +97,7 @@ export default function GlobalBlockListForm() {
           placeholder={`Enter emails or domains separated by comma, semicolon, or new line, e.g.\n@company.io\nuser@example.com`}
           value={blockListInput}
           onChange={(e) => setBlockListInput(e.target.value)}
+          disabled={isSaving}
           aria-invalid={invalidEntries.length > 0}
         />
         {invalidEntries.length > 0 ? (

--- a/components/settings/ignored-domains-form.tsx
+++ b/components/settings/ignored-domains-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useTeam } from "@/context/team-context";
 import { toast } from "sonner";
@@ -29,24 +29,20 @@ export default function IgnoredDomainsForm() {
   const [domainsInput, setDomainsInput] = useState("");
   const [initialDomainsInput, setInitialDomainsInput] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const hasUnsavedChanges = domainsInput !== initialDomainsInput;
 
   useEffect(() => {
-    if (ignoredDomains) {
+    if (ignoredDomains && !hasUnsavedChanges) {
       const val = ignoredDomains.join("\n");
       setDomainsInput(val);
       setInitialDomainsInput(val);
     }
-  }, [ignoredDomains]);
+  }, [ignoredDomains, hasUnsavedChanges]);
 
   const { invalid: invalidDomains } = validateList(domainsInput, "domain");
 
-  const saveDisabled = useMemo(() => {
-    return (
-      isSaving ||
-      domainsInput === initialDomainsInput ||
-      invalidDomains.length > 0
-    );
-  }, [isSaving, domainsInput, initialDomainsInput, invalidDomains]);
+  const saveDisabled =
+    isSaving || !hasUnsavedChanges || invalidDomains.length > 0;
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -64,6 +60,9 @@ export default function IgnoredDomainsForm() {
         throw new Error(error || "Failed to update ignored domains.");
       }
       await mutate();
+      const savedValue = domains.join("\n");
+      setDomainsInput(savedValue);
+      setInitialDomainsInput(savedValue);
       return res.json();
     });
 
@@ -98,6 +97,7 @@ export default function IgnoredDomainsForm() {
 @example.com`}
           value={domainsInput}
           onChange={(e) => setDomainsInput(e.target.value)}
+          disabled={isSaving}
           aria-invalid={invalidDomains.length > 0}
         />
         {invalidDomains.length > 0 ? (


### PR DESCRIPTION
typing in the global block list or ignored domains form could be overwritten whenever swr revalidated in the background.

the forms now apply server data only while the local draft is clean. after a successful save, both the displayed and baseline values move to the normalized persisted list.

checked both dirty/clean state paths and ran \`git diff --check\`. the workspace does not currently have dependencies installed, so full lint is left to ci.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unsaved global block list and ignored-domain edits from being overwritten when updated server values arrive.
  - Forms now correctly recognize whether changes are pending before synchronizing incoming values.
  - After saving, forms display the sanitized and normalized values that were accepted.
  - Save controls now accurately reflect whether there are changes to submit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->