### PR TITLE
fix: reset mobile document search on close

### DIFF
--- a/components/layouts/mobile-share-fab.tsx
+++ b/components/layouts/mobile-share-fab.tsx
@@ -87,6 +87,14 @@ export function MobileShareFab({ mode, dataroomId }: MobileShareFabProps) {
 
   const documents = docListData?.documents ?? [];
 
+  const handleDocumentPickerOpenChange = (open: boolean) => {
+    setDocPickerOpen(open);
+    if (!open) {
+      setDocSearch("");
+      setDebouncedDocSearch("");
+    }
+  };
+
   const openDataroomLinkFor = useCallback((id: string) => {
     setPickedDataroomId(id);
     setDrPickerOpen(false);
@@ -104,7 +112,7 @@ export function MobileShareFab({ mode, dataroomId }: MobileShareFabProps) {
 
   const handlePickDocument = (id: string) => {
     setPickedDocumentId(id);
-    setDocPickerOpen(false);
+    handleDocumentPickerOpenChange(false);
     setChooseOpen(false);
     setDocLinkOpen(true);
   };
@@ -156,7 +164,7 @@ export function MobileShareFab({ mode, dataroomId }: MobileShareFabProps) {
               className="h-auto justify-start gap-3 py-4 text-left"
               onClick={() => {
                 setChooseOpen(false);
-                setDocPickerOpen(true);
+                handleDocumentPickerOpenChange(true);
               }}
             >
               <FileTextIcon className="h-5 w-5 shrink-0" />
@@ -188,7 +196,10 @@ export function MobileShareFab({ mode, dataroomId }: MobileShareFabProps) {
         </SheetContent>
       </Sheet>
 
-      <Sheet open={docPickerOpen} onOpenChange={setDocPickerOpen}>
+      <Sheet
+        open={docPickerOpen}
+        onOpenChange={handleDocumentPickerOpenChange}
+      >
         <SheetContent
           side="bottom"
           className="flex max-h-[85dvh] flex-col rounded-t-xl border-t px-0 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2 md:hidden"
@@ -201,7 +212,7 @@ export function MobileShareFab({ mode, dataroomId }: MobileShareFabProps) {
                 variant="ghost"
                 size="icon"
                 className="shrink-0"
-                onClick={() => setDocPickerOpen(false)}
+                onClick={() => handleDocumentPickerOpenChange(false)}
               >
                 <XIcon className="h-5 w-5" />
               </Button>


### PR DESCRIPTION
the mobile share picker kept its previous document query after being dismissed or after a document was selected. reopening it could show an unexpectedly filtered list, including a stale empty state.

all close paths now clear both the visible query and its debounced value. reopening the picker starts from the full document list.

checked dismiss, selection, and reopen paths and ran \`git diff --check\`. full lint is left to ci because dependencies are not installed in this workspace.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document picker behavior when closing the sheet.
  * Document searches are now cleared when the picker closes, ensuring fresh search results the next time it opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->