### PR TITLE
fix: enforce team role change permissions

### DIFF
--- a/pages/api/teams/[teamId]/change-role.ts
+++ b/pages/api/teams/[teamId]/change-role.ts
@@ -46,21 +46,27 @@ export default async function handle(
         return res.status(401).json("Unauthorized");
       }
 
-      // Only ADMINs can change roles
-      if (role === "ADMIN" && userTeam.role !== "ADMIN") {
-        return res.status(403).json("Only admins can change user roles");
+      const targetMembership = await prisma.userTeam.findUnique({
+        where: {
+          userId_teamId: {
+            userId: userToBeChanged,
+            teamId,
+          },
+        },
+        select: { role: true },
+      });
+
+      if (!targetMembership) {
+        return res.status(404).json("Team member not found");
       }
 
-      // Managing the dataroom-scoped role (and its room assignments) is an
-      // ADMIN/MANAGER-only operation.
-      if (
+      const canManagerAssignDatarooms =
         role === "DATAROOM_MEMBER" &&
-        userTeam.role !== "ADMIN" &&
-        userTeam.role !== "MANAGER"
-      ) {
-        return res
-          .status(403)
-          .json("Only admins and managers can manage data room members");
+        userTeam.role === "MANAGER" &&
+        targetMembership.role !== "ADMIN";
+
+      if (userTeam.role !== "ADMIN" && !canManagerAssignDatarooms) {
+        return res.status(403).json("Only admins can change user roles");
       }
 
       if (userTeam?.role === "ADMIN" && userTeam.userId === userToBeChanged) {


### PR DESCRIPTION
the role endpoint only checked admin access when the requested role was admin. a regular member could promote or demote other members by posting a different role directly.

role changes now require an admin, while preserving the existing manager path for assigning non-admin users to specific data rooms. the target membership is also checked before any transaction runs.

reviewed member, manager, admin, missing-target, and self-admin paths and ran \`git diff --check\`. full lint is left to ci because dependencies are not installed in this workspace.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team role-change validation by confirming the target user belongs to the team.
  * Unauthorized role changes are now rejected consistently.
  * Managers can assign the standard member role to eligible non-admin users, while other role changes remain restricted to administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->