### PR TITLE
fix: scope group permissions to assigned data rooms

### DIFF
--- a/pages/api/teams/[teamId]/datarooms/[id]/groups/[groupId]/permissions.ts
+++ b/pages/api/teams/[teamId]/datarooms/[id]/groups/[groupId]/permissions.ts
@@ -5,6 +5,7 @@ import { ItemType } from "@prisma/client";
 import cuid from "cuid";
 import { getServerSession } from "next-auth/next";
 
+import { enforceDataroomMemberScope } from "@/lib/api/rbac/guard";
 import {
   buildBulkUpsertPermissionsSql,
   buildFindAncestorFolderIdsSql,
@@ -51,6 +52,17 @@ export default async function handler(
   };
 
   try {
+    if (
+      await enforceDataroomMemberScope({
+        userId,
+        teamId,
+        dataroomId,
+        res,
+      })
+    ) {
+      return;
+    }
+
     const { permissions } = req.body as {
       permissions: Record<
         string,


### PR DESCRIPTION
the viewer-group permissions route checked team membership but skipped the data room assignment guard. a data-room-scoped member could therefore post permission changes to another room in the same team.

the route now applies the same assignment guard used by neighboring group, folder, document, and analytics routes before processing permission rows.

reviewed assigned, unassigned, and non-scoped role paths and ran \`git diff --check\`. full lint is left to ci because dependencies are not installed in this workspace.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for dataroom group permission updates by enforcing member access checks before processing requests.
  - Unauthorized requests are now stopped before any permission changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->