### PR TITLE
fix: persist incoming webhook names

### DIFF
--- a/pages/api/teams/[teamId]/incoming-webhooks/index.ts
+++ b/pages/api/teams/[teamId]/incoming-webhooks/index.ts
@@ -103,10 +103,11 @@ export default async function handle(
         return res.status(401).json({ error: "Unauthorized" });
       }
 
-      const { name } = req.body;
-      if (!name) {
+      const name = req.body?.name;
+      if (typeof name !== "string" || !name.trim()) {
         return res.status(400).json({ error: "Name is required" });
       }
+      const trimmedName = name.trim();
 
       // Generate webhook ID and secret
       const webhookId = generateWebhookId(teamId);
@@ -114,7 +115,7 @@ export default async function handle(
       // Create incoming webhook
       const incomingWebhook = await prisma.incomingWebhook.create({
         data: {
-          name: "New Incoming Webhook",
+          name: trimmedName,
           externalId: webhookId,
           teamId,
         },


### PR DESCRIPTION
the incoming webhook endpoint validated a submitted name and then discarded it, so every new row was stored as \`New Incoming Webhook\`.

the endpoint now rejects non-string and whitespace-only values, trims valid input, and persists that name.

validated missing, whitespace, and valid request paths and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)