### PR TITLE
fix: stop tag and preset routes after auth errors

### DIFF
--- a/pages/api/teams/[teamId]/presets/[id].ts
+++ b/pages/api/teams/[teamId]/presets/[id].ts
@@ -51,6 +51,7 @@ export default async function handle(
     }
   } catch (error) {
     errorhandler(error, res);
+    return;
   }
 
   if (req.method === "GET") {

--- a/pages/api/teams/[teamId]/tags/[id]/index.ts
+++ b/pages/api/teams/[teamId]/tags/[id]/index.ts
@@ -43,6 +43,7 @@ export default async function handle(
     }
   } catch (error) {
     errorhandler(error, res);
+    return;
   }
   if (req.method === "PUT") {
     // PUT /api/teams/:teamId/tags/[id]

--- a/pages/api/teams/[teamId]/tags/index.ts
+++ b/pages/api/teams/[teamId]/tags/index.ts
@@ -113,6 +113,7 @@ export default async function handle(
     }
   } catch (error) {
     errorhandler(error, res);
+    return;
   }
   if (req.method === "GET") {
     // GET /api/teams/:teamId/tag


### PR DESCRIPTION
three tag and preset handlers sent membership lookup errors through the shared error handler but then continued into normal request processing.

those catch paths now return immediately, preventing database work and a second response after an authorization lookup failure.

checked all three handler paths and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)