### PR TITLE
fix: preserve webhook edits during revalidation

### DIFF
--- a/pages/settings/webhooks/[id]/index.tsx
+++ b/pages/settings/webhooks/[id]/index.tsx
@@ -55,13 +55,13 @@ export default function WebhookDetail() {
   );
 
   useEffect(() => {
-    if (webhook) {
+    if (webhook && !isEditing) {
       setFormData({
         name: webhook.name,
         triggers: webhook.triggers as string[],
       });
     }
-  }, [webhook]);
+  }, [isEditing, webhook]);
 
   const handleUpdate = async () => {
     if ((isFree || isPro) && !isTrial) {
@@ -353,7 +353,15 @@ export default function WebhookDetail() {
                         <Button
                           variant="outline"
                           className="dark:bg-transparent dark:hover:bg-muted"
-                          onClick={() => setIsEditing(false)}
+                          onClick={() => {
+                            if (webhook) {
+                              setFormData({
+                                name: webhook.name,
+                                triggers: webhook.triggers as string[],
+                              });
+                            }
+                            setIsEditing(false);
+                          }}
                         >
                           Cancel
                         </Button>


### PR DESCRIPTION
swr refreshes could replace a webhook draft while it was being edited. cancel had the opposite problem: the unsaved draft stayed in local state and reappeared the next time editing opened.

server values now sync only outside edit mode, and cancel explicitly restores the persisted name and triggers.

validated edit, revalidation, cancel, and reopen paths and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented webhook details from unexpectedly overwriting unsaved form changes while editing.
  * Updated the Cancel action to restore the webhook’s current name before exiting edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->