### PR TITLE
fix: return one 404 for missing document renames

### DIFF
--- a/pages/api/teams/[teamId]/documents/[id]/update-name.ts
+++ b/pages/api/teams/[teamId]/documents/[id]/update-name.ts
@@ -73,7 +73,7 @@ export default async function handle(
         });
 
         if (!document) {
-          return res.status(404).json({ error: "Document not found" });
+          return null;
         }
 
         const updateResult = await tx.document.update({
@@ -84,7 +84,6 @@ export default async function handle(
         return updateResult;
       });
 
-      // Check if any rows were affected
       if (!result) {
         return res.status(404).json({ error: "Document not found" });
       }


### PR DESCRIPTION
the rename transaction returned a next api response object when the document was missing. because that object is truthy, the outer handler could continue into its success response after already sending 404.

the transaction now returns null for the missing row and the handler emits a single 404 after the transaction.

validated missing and successful result paths and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)