### PR TITLE
fix: preserve folder form after create errors

### DIFF
--- a/components/folders/add-folder-modal.tsx
+++ b/components/folders/add-folder-modal.tsx
@@ -132,9 +132,14 @@ export function AddFolderModal({
       );
 
       if (!response.ok) {
-        const { message } = await response.json();
-        setLoading(false);
-        toast.error(message.error);
+        const responseBody = await response.json();
+        const errorMessage =
+          typeof responseBody?.message === "string"
+            ? responseBody.message
+            : typeof responseBody?.error === "string"
+              ? responseBody.error
+              : "Error adding folder. Please try again.";
+        toast.error(errorMessage);
         return;
       }
 
@@ -162,16 +167,14 @@ export function AddFolderModal({
       mutate(
         `/api/teams/${teamInfo?.currentTeam?.id}/${endpointTargetType}${parentFolderPath}`,
       );
-    } catch (error) {
-      setLoading(false);
-      toast.error("Error adding folder. Please try again.");
-      return;
-    } finally {
       setFolderName("");
       setFolderIcon(DEFAULT_FOLDER_ICON);
       setFolderColor(DEFAULT_FOLDER_COLOR);
-      setLoading(false);
       setOpen(false);
+    } catch (error) {
+      toast.error("Error adding folder. Please try again.");
+    } finally {
+      setLoading(false);
     }
   };
 


### PR DESCRIPTION
folder creation failures read the api's string message as an object, which produced a blank toast. the unconditional cleanup also closed the modal and erased the draft before the user could retry.

error responses now resolve either supported message shape, while reset and close only run after a successful create. network failures follow the same retryable path.

validated the success, api error, and network error branches and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder creation error messages when the server provides details or no specific message is available.
  * Preserved entered folder details after an unsuccessful submission.
  * Ensured the loading state clears consistently after folder creation attempts.
  * Reset folder form fields only after a folder is created successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->