### PR TITLE
fix: require an event when creating webhooks

### DIFF
--- a/lib/zod/schemas/webhooks.ts
+++ b/lib/zod/schemas/webhooks.ts
@@ -6,7 +6,9 @@ export const createWebhookSchema = z.object({
   name: z.string().min(1).max(40),
   url: z.string().url().max(190),
   secret: z.string().startsWith("whsec_"),
-  triggers: z.array(z.enum(WEBHOOK_TRIGGERS)),
+  triggers: z
+    .array(z.enum(WEBHOOK_TRIGGERS))
+    .min(1, "Select at least one event trigger."),
 });
 
 export const updateWebhookSchema = createWebhookSchema.partial();

--- a/pages/settings/webhooks/new.tsx
+++ b/pages/settings/webhooks/new.tsx
@@ -68,7 +68,9 @@ const formSchema = z.object({
     .min(3, "Please provide a webhook name with at least 3 characters."),
   url: z.string().url("Please enter a valid URL."),
   secret: z.string(),
-  triggers: z.array(z.string()),
+  triggers: z
+    .array(z.string())
+    .min(1, "Select at least one event trigger."),
 });
 
 export default function NewWebhook() {
@@ -344,11 +346,14 @@ export default function NewWebhook() {
                   trigger="create_webhook"
                   highlightItem={["webhooks"]}
                   type="submit"
-                  disabled={isLoading}
+                  disabled={isLoading || formData.triggers.length === 0}
                   key="create-webhook"
                 />
               ) : (
-                <Button type="submit" disabled={isLoading}>
+                <Button
+                  type="submit"
+                  disabled={isLoading || formData.triggers.length === 0}
+                >
                   {isLoading ? "Creating..." : "Create Webhook"}
                 </Button>
               )}


### PR DESCRIPTION
the create page says at least one event is required, but both schemas accepted an empty trigger list and created a webhook that could never fire.

this enforces the invariant in the browser and api schema, and keeps submit disabled until an event is selected.

validated both schema paths and submit states and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)