### PR TITLE
fix: wait for every page of S3 copies

### DIFF
--- a/lib/files/copy-file-server.ts
+++ b/lib/files/copy-file-server.ts
@@ -133,7 +133,7 @@ async function copyFolder(
       }
     }
     if (list.NextContinuationToken) {
-      recursiveCopy(list.NextContinuationToken);
+      return recursiveCopy(list.NextContinuationToken);
     }
     return `${count} files copied.`;
   };


### PR DESCRIPTION
copying an s3-backed document returned as soon as the first \`ListObjectsV2\` page finished. recursive pages were started without returning their promise, so documents with more than 1,000 objects could be reported complete while most objects were still copying.

the continuation branch now returns the recursive promise, keeping the copy operation pending through the final page and propagating later-page failures.

traced single-page and multi-page return paths and ran \`git diff --check\`.

Made with [Cursor](https://cursor.com)